### PR TITLE
Implement define method for tests, simplify test

### DIFF
--- a/src/PosthogProxy.php
+++ b/src/PosthogProxy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Findymail\PennantPosthogDriver;
+
+use PostHog\PostHog;
+
+class PosthogProxy
+{
+    public function isFeatureEnabled(
+        string $key,
+        string $distinctId,
+    ): null | bool {
+        return PostHog::isFeatureEnabled(
+            $key,
+            $distinctId,
+        );
+    }
+}

--- a/src/Providers/PennantPosthogDriverServiceProvider.php
+++ b/src/Providers/PennantPosthogDriverServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Findymail\PennantPosthogDriver\Providers;
 
 use Findymail\PennantPosthogDriver\Driver\PostHogDriver;
+use Findymail\PennantPosthogDriver\PosthogProxy;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Pennant\Feature;
@@ -24,9 +25,9 @@ class PennantPosthogDriverServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(PostHogDriver::class, function (Application $app) {
-            PostHog::init();
+            $postHogProxy = $app->make(PosthogProxy::class);
 
-            return new PostHogDriver([]);
+            return new PostHogDriver([], $postHogProxy);
         });
     }
 }

--- a/tests/Feature/PennantPosthogDriverTest.php
+++ b/tests/Feature/PennantPosthogDriverTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature;
 
+use Findymail\PennantPosthogDriver\PosthogProxy;
 use Illuminate\Support\Facades\Config;
-use Laravel\Pennant\FeatureManager;
+use Laravel\Pennant\Feature;
 use Mockery;
-use PostHog\PostHog;
 use Tests\TestCase;
 
 class PennantPosthogDriverTest extends TestCase
@@ -22,78 +22,66 @@ class PennantPosthogDriverTest extends TestCase
     public function it_should_true_when_posthog_feature_flag_is_enable(): void
     {
         // prepare
-        $featureManager = $this->app->make(FeatureManager::class);
-
-        $mock = Mockery::mock('alias:' . PostHog::class);
-
+        $mock = $this->mock(PosthogProxy::class);
         $mock->shouldReceive('isFeatureEnabled')
             ->once()
             ->with('test-feature-flag', '')
             ->andReturn(true);
 
-        $mock->shouldReceive('init');
-
         // process
-        $result = $featureManager->active('test-feature-flag', '');
+        $result = Feature::active('test-feature-flag', '');
 
         // test
         $this->assertTrue($result);
+
+        Mockery::close();
     }
 
     /** @test */
     public function should_return_false_when_posthog_feature_flag_is_disabled(): void
     {
         // prepare
-        $featureManager = $this->app->make(FeatureManager::class);
-
-        $mock = Mockery::mock('alias:' . PostHog::class);
-
+        $mock = $this->mock(PosthogProxy::class);
         $mock->shouldReceive('isFeatureEnabled')
             ->once()
             ->with('test-feature-flag', '')
-            ->andReturn(null);
-
-        $mock->shouldReceive('init');
+            ->andReturnNull();
 
         // process
-        $result = $featureManager->active('test-feature-flag', '');
+        $result = Feature::active('test-feature-flag', '');
 
         // test
         $this->assertFalse($result);
+
+        Mockery::close();
     }
 
     /** @test */
     public function should_call_only_once_posthog_API_even_if_called_twice(): void
     {
         // prepare
-        $featureManager = $this->app->make(FeatureManager::class);
-
-        $mock = Mockery::mock('alias:' . PostHog::class);
-
+        $mock = $this->mock(PosthogProxy::class);
         $mock->shouldReceive('isFeatureEnabled')
             ->once()
             ->with('test-feature-flag', '')
             ->andReturn(true);
 
-        $mock->shouldReceive('init');
-
         // process
-        $result1 = $featureManager->active('test-feature-flag', '');
-        $result2 = $featureManager->active('test-feature-flag', '');
+        $result1 = Feature::active('test-feature-flag', '');
+        $result2 = Feature::active('test-feature-flag', '');
 
         // tests
         $this->assertTrue($result1);
         $this->assertTrue($result2);
+
+        Mockery::close();
     }
 
     /** @test */
     public function should_call_allAreActiveProperly(): void
     {
         // prepare
-        $featureManager = $this->app->make(FeatureManager::class);
-
-        $mock = Mockery::mock('alias:' . PostHog::class);
-
+        $mock = $this->mock(PosthogProxy::class);
         $mock->shouldReceive('isFeatureEnabled')
             ->once()
             ->with('test-feature-flag1', '')
@@ -104,10 +92,65 @@ class PennantPosthogDriverTest extends TestCase
             ->with('test-feature-flag2', '')
             ->andReturn(true);
 
-        $mock->shouldReceive('init');
 
         // process
-        $result = $featureManager->allAreActive(['test-feature-flag1', 'test-feature-flag2']);
+        $result = Feature::allAreActive(['test-feature-flag1', 'test-feature-flag2']);
+
+        // tests
+        $this->assertTrue($result);
+
+    }
+
+    /** @test */
+    public function it_should_able_to_use_define_method_callable_true(): void
+    {
+        // prepare
+        Feature::define('defined-ff', fn () => true);
+
+        // process
+        $result = Feature::active('defined-ff');
+
+        // tests
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_should_able_to_use_define_method_callable_false(): void
+    {
+        // prepare
+        Feature::define('defined-ff', fn () => false);
+
+        // process
+        $result = Feature::active('defined-ff');
+
+        // tests
+        $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_should_able_to_return_defined_value(): void
+    {
+        // prepare
+        Feature::define('defined-ff', 'theValue');
+
+        // process
+        $result = Feature::active('defined-ff');
+
+        // tests
+        $this->assertEquals('theValue', $result);
+    }
+
+    /** @test */
+    public function it_should_not_call_posthog_driver_when_feature_flag_is_defined()
+    {
+        // prepare
+        $mock = $this->mock(PosthogProxy::class);
+        $mock->shouldReceive('isFeatureEnabled')->never();
+
+        Feature::define('defined-ff', fn () => true);
+
+        // process
+        $result = Feature::active('defined-ff');
 
         // tests
         $this->assertTrue($result);


### PR DESCRIPTION
This PR implement : 

- define method : to be able to mock Pennant in test
- defined method : related to defne
- simply test : use a Proxy to be able to mock easly posthog call